### PR TITLE
Added support for using ec2  tags as subitutions in tools

### DIFF
--- a/ec2ui/content/ec2ui/dialog_manage_tools.xul
+++ b/ec2ui/content/ec2ui/dialog_manage_tools.xul
@@ -92,6 +92,9 @@
         <hbox>
             <description>${pass} - The Administrator password for a Windows instance.</description>
         </hbox>
+        <hbox>
+            <description>${&lt;ec2 tag&gt;} - The EC2 tag will be replaced with its value.  MyGroup:foobar ${MyGroup}  = foobar</description>
+        </hbox>
     </vbox>
 
 </dialog>

--- a/ec2ui/content/ec2ui/instancesview.js
+++ b/ec2ui/content/ec2ui/instancesview.js
@@ -1600,6 +1600,16 @@ outer:
         argStr = argStr.replace(/\${privateDnsName}/g, instance.privateDnsName);
         argStr = argStr.replace(/\${privateIpAddress}/g, instance.privateIpAddress);
         argStr = argStr.replace(/\${name}/g, instance.name);
+  
+        //replace with any tag's value
+        var tagValuePairs=instance.tag.split(",");
+        for(i in tagValuePairs) {
+            var tagName = tagValuePairs[i].split(":")[0].trim();
+            var tagValue = tagValuePairs[i].split(":")[1].trim();
+
+            var re = new RegExp("\\${" + tagName + "}","g");
+            argStr = argStr.replace(re, tagValue);
+        } 
 
         // Finally, split args into an array
         var args = tokenise(argStr);


### PR DESCRIPTION
Add the ability to use ec2 tags in the tools.  For example a tag of MyGroup:group_name as a defined tag on the instance can use used as ${MyGroup}.
